### PR TITLE
Add data-tag-class and usage

### DIFF
--- a/dist/bootstrap-tagsinput.js
+++ b/dist/bootstrap-tagsinput.js
@@ -23,6 +23,7 @@
    * Constructor function
    */
   function TagsInput(element, options) {
+    var tagClass;
     this.itemsArray = [];
 
     this.$element = $(element);
@@ -39,6 +40,13 @@
 
     this.$element.after(this.$container);
 
+    options = options || {};   
+    if(options.tagClass == undefined){
+      tagClass = this.$element.data('tag-class');
+      if(tagClass)
+        options.tagClass = function(){ return tagClass;};
+    }
+    
     this.build(options);
   }
 


### PR DESCRIPTION
Modifies TagsInput to read from the `data-tags-class` if a `tagsClass` property isn't already set in `options`. Allows tag class to be set in markup for automatically processed inputs.
