### PR TITLE
arg1 & arg2 are null on blank inputs

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -431,7 +431,10 @@
         $(this).val($(this).val());
       } else {
         // Invoke function on existing tags input
-        var retVal = tagsinput[arg1](arg2);
+        var retVal = arg1 != null && arg2 != null 
+		  ? tagsinput[arg1](arg2)
+		  : undefined;
+		
         if (retVal !== undefined)
           results.push(retVal);
       }


### PR DESCRIPTION
There's a bug that appears when an input is initialised w/ an empty value and the same input has tagsinput() re-executed upon it.  

Added simple Ternary statement prior to using the `arg1` and `arg2` properties. 

Side note, might be good to name them appropriately.
