### PR TITLE
trigger removeAll on form reset event

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -27,6 +27,8 @@
    * Constructor function
    */
   function TagsInput(element, options) {
+    var self = this;
+
     this.itemsArray = [];
 
     this.$element = $(element);
@@ -42,6 +44,9 @@
     this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
 
     this.$element.after(this.$container);
+    this.$element.parents('form').off('reset.tagsinput').on('reset.tagsinput', function () {
+      self.removeAll.call(self);
+    });
 
     var inputWidth = (this.inputSize < 3 ? 3 : this.inputSize) + "em";
     this.$input.get(0).style.cssText = "width: " + inputWidth + " !important;";
@@ -263,7 +268,7 @@
       makeOptionItemFunction(self.options, 'itemValue');
       makeOptionItemFunction(self.options, 'itemText');
       makeOptionFunction(self.options, 'tagClass');
-      
+
       // Typeahead Bootstrap version 2.3.2
       if (self.options.typeahead) {
         var typeahead = self.options.typeahead || {};
@@ -318,7 +323,7 @@
       // typeahead.js
       if (self.options.typeaheadjs) {
           var typeaheadjs = self.options.typeaheadjs || {};
-          
+
           self.$input.typeahead(null, typeaheadjs).on('typeahead:selected', $.proxy(function (obj, datum) {
             if (typeaheadjs.valueKey)
               self.add(datum[typeaheadjs.valueKey]);
@@ -345,7 +350,7 @@
               }
           }, self));
         }
-        
+
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {
         var $input = $(event.target),
@@ -581,7 +586,7 @@
   }
 
   /**
-    * Returns boolean indicates whether user has pressed an expected key combination. 
+    * Returns boolean indicates whether user has pressed an expected key combination.
     * @param object keyPressEvent: JavaScript event object, refer
     *     http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
     * @param object lookupList: expected key combinations, as in:


### PR DESCRIPTION
resolves #204

--tag editor removed trailing whitespace in case you were curious
