### PR TITLE
Remove  bootstrap-tagsinput-max class in removeAll

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -195,6 +195,7 @@
 
       $('.tag', self.$container).remove();
       $('option', self.$element).remove();
+      self.$container.removeClass('bootstrap-tagsinput-max');
 
       while(self.itemsArray.length > 0)
         self.itemsArray.pop();


### PR DESCRIPTION
When removing a single item, the bootstrap-tagsinput-max class is correctly removed. When calling removeAll, it is not. Fixed.
