### PR TITLE
Fix for Typeahead with freeInput=false Submitting Form

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -420,6 +420,8 @@
             self.add(maxLengthReached ? text.substr(0, self.options.maxChars) : text);
             $input.val('');
             event.preventDefault();
+         }else if(!self.options.freeInput && (keyCombinationInList(event, self.options.confirmKeys) || maxLengthReached)){
+            event.preventDefault();
          }
 
          // Reset internal input's size


### PR DESCRIPTION
When the bootstrap-taginput is used within a form and is set to make use of a typeahead plugin, setting the freeInput to false fails to handle the default action of an enter key press.

Code change prevents default action if this isn't handled immediately beforehand.
