### PR TITLE
Fix existing tag search

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -108,7 +108,7 @@
           tagClass = self.options.tagClass(item);
 
       // Ignore items allready added
-      var existing = $.grep(self.itemsArray, function(item) { return self.options.itemValue(item) === itemValue; } )[0];
+      var existing = $.grep(self.itemsArray, function(item) { return ( self.options.itemValue(item) === itemValue || (!self.objectItems && self.options.itemText(item) === itemText) ); } )[0];
       if (existing && !self.options.allowDuplicates) {
         // Invoke onTagExists
         if (self.options.onTagExists) {


### PR DESCRIPTION
Addresses an issue where modifying tag text using the itemText function could result in duplicate tags.

**_Example:**_
When the below function is active, entering text "test.dot" and "t.estdot" results in the duplicate tag "testdot"

```
$('input').tagsinput({
        itemText: function(item) {
            return this.itemValue(item).replace('.','');
        }
    });
```
