### PR TITLE
Allow for multiple datasets in typeaheadjs

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -341,21 +341,21 @@
 
       // typeahead.js
       if (self.options.typeaheadjs) {
-          var typeaheadConfig = null;
-          var typeaheadDatasets = {};
-
-          // Determine if main configurations were passed or simply a dataset
-          var typeaheadjs = self.options.typeaheadjs;
-          if ($.isArray(typeaheadjs)) {
-            typeaheadConfig = typeaheadjs[0];
-            typeaheadDatasets = typeaheadjs[1];
-          } else {
-            typeaheadDatasets = typeaheadjs;
-          }
-
-          self.$input.typeahead(typeaheadConfig, typeaheadDatasets).on('typeahead:selected', $.proxy(function (obj, datum) {
-            if (typeaheadDatasets.valueKey)
-              self.add(datum[typeaheadDatasets.valueKey]);
+          var config = self.options.config;
+          var typeaheadjs = self.options.typeaheadjs || [];
+          var typeahead_array = (typeaheadjs instanceof Array) ? typeaheadjs : [typeaheadjs];
+          self.$input.typeahead.apply(self.$input, [config].concat(typeahead_array))
+              .on('typeahead:selected', $.proxy(function (obj, datum, name) {
+            var index = 0;
+            typeahead_array.some(function(e, i) {
+                if (e.name===name) {
+                    index = i;
+                    return true;
+                } else
+                    return false;
+            });
+            if (typeahead_array[index].valueKey)
+              self.add(datum[typeahead_array[index].valueKey]);
             else
               self.add(datum);
             self.$input.typeahead('val', '');


### PR DESCRIPTION
This PR is meant to allow for multiple typeaheadjs instances to be given to tagsinput to perform autocompletion of multiple datasets at the same time, like in this example:

https://twitter.github.io/typeahead.js/examples/#multiple-datasets

You now can pass an array of objects rather than a single typeaheadjs object but a single typeahead instance is still allowed.

Example:

``` HTML
<script>
var nbaTeams = new Bloodhound({
  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('team'),
  queryTokenizer: Bloodhound.tokenizers.whitespace,
  local:  [
    { "team": "Boston Celtics" },
    { "team": "Dallas Mavericks" },
    { "team": "Brooklyn Nets" },
    { "team": "Houston Rockets" }
  ]
});

var nhlTeams = new Bloodhound({
  datumTokenizer: Bloodhound.tokenizers.obj.whitespace('team'),
  queryTokenizer: Bloodhound.tokenizers.whitespace,
  local: [
    { "team": "Dallas Stars" },
    { "team": "Los Angeles Kings" },
    { "team": "Phoenix Coyotes" },
    { "team": "San Jose Sharks" }
  ]
});

nbaTeams.initialize();
nhlTeams.initialize();

$('input').tagsinput({ 
  typeaheadjs:  [{
    name: 'nba-teams',
    displayKey: 'team',
    source: nbaTeams.ttAdapter(),
      templates: {
      header: '<h3 class="league-name">NBA Teams</h3>'
    }
}, {
    name: 'nhl-teams',
    displayKey: 'team',
    source: nhlTeams.ttAdapter(),
    templates: {
      header: '<h3 class="league-name">NHL Teams</h3>'
    }
  }]
});
</script>
```
