### PR TITLE
Removing encodeURIComponent from already added option check

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -132,7 +132,7 @@
       $tag.after(' ');
 
       // add <option /> if item represents a value not present in one of the <select />'s options
-      if (self.isSelect && !$('option[value="' + encodeURIComponent(itemValue) + '"]',self.$element)[0]) {
+      if (self.isSelect && !$('option[value="' + itemValue + '"]',self.$element)[0]) {
         var $option = $('<option selected>' + htmlEncode(itemText) + '</option>');
         $option.data('item', item);
         $option.attr('value', itemValue);


### PR DESCRIPTION
Using an `encodeURIComponent` in the option selection will fail for any options that use encodable characters such as spaces. This results in duplicate option tags getting generated for any value containing spaces.
