### PR TITLE
Fix check for empty tags when removing upon a backspace event

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -361,7 +361,7 @@
           case 8:
             if (doGetCaretPosition($input[0]) === 0) {
               var prev = $inputWrapper.prev();
-              if (prev) {
+              if (prev.length) {
                 self.remove(prev.data('item'));
               }
             }


### PR DESCRIPTION
Currently `remove()` fires (and the `itemRemoved` event thus triggers) upon hitting backspace even when there are no tags. 

This is do to a bug in the check for `if(prev)`.  This is a jquery object and thus the check needs to be for `if(prev.length)`.
