### PR TITLE
Add scss file

### DIFF
--- a/dist/bootstrap-tagsinput.scss
+++ b/dist/bootstrap-tagsinput.scss
@@ -1,0 +1,46 @@
+.bootstrap-tagsinput {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  display: inline-block;
+  padding: 4px 6px;
+  margin-bottom: 10px;
+  color: #555;
+  vertical-align: middle;
+  border-radius: 4px;
+  max-width: 100%;
+  line-height: 22px;
+  cursor: text;
+  input {
+    border: none;
+    box-shadow: none;
+    outline: none;
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    width: auto !important;
+    max-width: inherit;
+    &:focus {
+      border: none;
+      box-shadow: none;
+    }
+  }
+  .tag {
+    margin-right: 2px;
+    color: white;
+    [data-role="remove"] {
+      margin-left: 8px;
+      cursor: pointer;
+      &:after {
+        content: "x";
+        padding: 0px 2px;
+      }
+      &:hover {
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05);
+        &:active {
+          box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
With `wiredep` task I can overwide the plugin and inject only I need. See:

``` js
wiredep: {
  app: {
    overrides: {
      'bootstrap-tagsinput': {
        main: [
          './dist/bootstrap-tagsinput.js',
          './dist/bootstrap-tagsinput.scss',
        ]
      }
    }
  }
}
```

Reference of #303
