### PR TITLE
Add support to inherit class

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -40,8 +40,9 @@
     this.objectItems = options && options.itemValue;
     this.placeholderText = element.hasAttribute('placeholder') ? this.$element.attr('placeholder') : '';
     this.inputSize = Math.max(1, this.placeholderText.length);
+    this.class = element.hasAttribute('class') ? ' ' + this.$element.attr('class') : '';
 
-    this.$container = $('<div class="bootstrap-tagsinput"></div>');
+    this.$container = $('<div class="bootstrap-tagsinput' + this.class + '"></div>');
     this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
 
     this.$element.after(this.$container);


### PR DESCRIPTION
Simple way to inherit class. In my case I use bootstrap and another class to set width, see example below:

``` html
<form class="form" role="form">
  <div class="form-group">
    <label for="tags">Tags</label>
    <input type="text" class="form-control form-tag wlg" id="tags" value="" placeholder="Tags" required>
  </div>
</div>
```

``` css
.wlg {
  max-width: 400px;
}
```

``` js
$('.form-tag').tagsinput({
  tagClass: function() {
    return 'label label-primary';
  }
});
```

Works like a charm.
