### PR TITLE
Make test check for last not first element

### DIFF
--- a/test/bootstrap-tagsinput/input_with_string_items.tests.js
+++ b/test/bootstrap-tagsinput/input_with_string_items.tests.js
@@ -140,7 +140,7 @@ describe("bootstrap-tagsinput", function() {
 
         it('after last tag, should remove the last tag', function() {
           this.$tagsinput_input.trigger($.Event('keydown', { which: 8 }));
-          expect(this.$element.tagsinput('items')[0]).toBe('some');
+          expect(this.$element.tagsinput('items')[this.$element.tagsinput('items').length-1]).toBe('some');
         });
 
         it('after last tag, should remove the last tag', function() {


### PR DESCRIPTION
When creating another feature I realized that the `after last tag, should remove the last tag` test is not actually checking what it claims to do. When pressing backspace it should make sure, that the example array only contains `some`. It does that by checking for the first element.

If we were to remove the backspace functionality we would be left with the same array that we started out with after pressing backspace: `['some', 'tags']`. We can see here that the last string is still `tags` (so it was not deleted). But since we are checking for the first tag to be `some` it looks like the test passed. 
We should therefore make sure that the last item is deleted by checking for the last item in the array as I did it in the PR.
