### PR TITLE
Updated open typeahead window check

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -339,7 +339,7 @@
           self.$input.on('focusout', $.proxy(function(event) {
               // HACK: only process on focusout when no typeahead opened, to
               //       avoid adding the typeahead text as tag
-              if ($('.typeahead, .twitter-typeahead', self.$container).length === 0) {
+              if (!$('.typeahead, .twitter-typeahead', self.$container).is(':visible')) {
                 self.add(self.$input.val());
                 self.$input.val('');
               }


### PR DESCRIPTION
When .length === 0 is used, the add on focusout effect gets canceled even when no typeahead window is visible.
I used !is(':visible') because .not(':visible') returns the jQuery items instead of a true or false.