### PR TITLE
Typo in gruntfile, replacing bower by grunt in readme

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
       }
     },
     zip: {
-      delpoy: {
+      deploy: {
         // cwd: 'dist/',
         src:  [
             'dist/bootstrap-tagsinput*.js',

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Integrates with Twitter Bootstraps' 2.3.2 typeahead, or use custom typeahead whe
 Install dependencies:
 <pre>
 npm install
-bower install
+grunt install
 </pre>
 Test:
 <pre>


### PR DESCRIPTION
If you follow the readme by doing a `bower install`, dependencies will end up in `bower_components`.
`grunt install` puts them in the right folder (`lib/`).

Also fixes a typo in zip:deploy target in the grunt file.
