### PR TITLE
Supported class attribute to input tag.

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -39,10 +39,11 @@
     this.multiple = (this.isSelect && element.hasAttribute('multiple'));
     this.objectItems = options && options.itemValue;
     this.placeholderText = element.hasAttribute('placeholder') ? this.$element.attr('placeholder') : '';
+    this.classAttr = element.hasAttribute('class') ? ' class="' + this.$element.attr('class') + '"' : '';
     this.inputSize = Math.max(1, this.placeholderText.length);
 
     this.$container = $('<div class="bootstrap-tagsinput"></div>');
-    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
+    this.$input = $('<input type="text"' + this.classAttr + ' placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
 
     this.$element.before(this.$container);
 


### PR DESCRIPTION
``` html
<input type='text' data-role='tagsinput' class='form-control' />
```

to

``` html
<div class='bootstrap-tagsinput'>
  <input type='text' data-role='tagsinput' class='form-control' placeholder='' />
</div>
```

see #308 :+1: 
but I think it should be a class attribute is inherited in an input tag :)
