### PR TITLE
Fix tag insertion at specific position

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -123,7 +123,8 @@
         return;
 
       // register item in internal array and map
-      self.itemsArray.push(item);
+      var $inputWrapper = self.findInputWrapper();
+      self.itemsArray.splice($inputWrapper.index(), 0, item);
 
       // add a tag element
 


### PR DESCRIPTION
Tags inserted at specific positions where not registered at 
the same position internally but always appended instead.

This fix takes the current position of the input wrapper in
relation to its siblings (the tags) into account.

Fixes #349
