### PR TITLE
Fixed typeahead and free input issue

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -351,9 +351,10 @@
           self.$input.on('focusout', $.proxy(function(event) {
               // HACK: only process on focusout when no typeahead opened, to
               //       avoid adding the typeahead text as tag
-              if ($('.typeahead, .twitter-typeahead', self.$container).length === 0) {
+              if ($('.tt-hint', self.$container).val().length === 0) {
                 self.add(self.$input.val());
-                self.$input.val('');
+                self.$input.typeahead('val', '');
+                self.$input.typeahead('close');
               }
           }, self));
         }


### PR DESCRIPTION
Based on this open issue https://github.com/timschlechter/bootstrap-tagsinput/issues/387
