### PR TITLE
Add scope.$apply when a tag is added/removed (AngularJS)

### DIFF
--- a/src/bootstrap-tagsinput-angular.js
+++ b/src/bootstrap-tagsinput-angular.js
@@ -49,13 +49,13 @@ angular.module('bootstrap-tagsinput', [])
 
         select.on('itemAdded', function(event) {
           if (scope.model.indexOf(event.item) === -1)
-            scope.model.push(event.item);
+            scope.$apply(function(){scope.model.push(event.item);});
         });
 
         select.on('itemRemoved', function(event) {
           var idx = scope.model.indexOf(event.item);
           if (idx !== -1)
-            scope.model.splice(idx, 1);
+            scope.$apply(function(){ scope.model.splice(idx, 1); });
         });
 
         // create a shallow copy of model's current state, needed to determine


### PR DESCRIPTION
Why:

When a tag is added/ removed the model is not updated because the event
do not trigger the $digest() function therefore it was necessary
wrap the model assignment with a $scope.$apply function.
