### PR TITLE
`encodeUriComponent` converts spaces among others

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -133,7 +133,11 @@
       $tag.after(' ');
 
       // add <option /> if item represents a value not present in one of the <select />'s options
-      if (self.isSelect && !$('option[value="' + itemValue.replace(/"/g, '\\"') + '"]',self.$element)[0]) {
+      var fixedItemValue = itemValue;
+      if (typeof itemValue == 'string') {
+        fixedItemValue = itemValue.replace(/"/g, '\\"');
+      }
+      if (self.isSelect && !$('option[value="' + fixedItemValue + '"]',self.$element)[0]) {
         var $option = $('<option selected>' + htmlEncode(itemText) + '</option>');
         $option.data('item', item);
         $option.attr('value', itemValue);

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -133,7 +133,7 @@
       $tag.after(' ');
 
       // add <option /> if item represents a value not present in one of the <select />'s options
-      if (self.isSelect && !$('option[value="' + encodeURIComponent(itemValue) + '"]',self.$element)[0]) {
+      if (self.isSelect && !$('option[value="' + itemValue.replace(/"/g, '\\"') + '"]',self.$element)[0]) {
         var $option = $('<option selected>' + htmlEncode(itemText) + '</option>');
         $option.data('item', item);
         $option.attr('value', itemValue);


### PR DESCRIPTION
Escaping `"` instead.
Why anyone would want a tag with `"` in it is beyond me.

End result when using `encodeUriComponent`:

If a tag contains spaces, it will not be matched with any existing tag, hence a new tag is created, causing duplicates in the list of tags.
