### PR TITLE
hides IE10+ clear field icon in input field

### DIFF
--- a/src/bootstrap-tagsinput.css
+++ b/src/bootstrap-tagsinput.css
@@ -21,6 +21,9 @@
   width: auto;
   max-width: inherit;
 }
+.bootstrap-tagsinput.form-control input::-ms-clear {
+    display: none;
+}
 .bootstrap-tagsinput.form-control input::-moz-placeholder {
   color: #777;
   opacity: 1;


### PR DESCRIPTION
looks confusing for users, when a clear field icon appears in middle of the tags input field on IE10+ browsers
