### PR TITLE
Removed duplicate 'removeAll' entry from examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -612,14 +612,6 @@ $('#tags-input').on('beforeItemRemove', function(event) {
               </td>
             </tr>
             <tr>
-              <td><code>removeAll</code></td>
-              <td>
-                <p>Removes all tags</p>
-
-                <pre><code data-language="javascript">$('input').tagsinput('removeAll');</code></pre>
-              </td>
-            </tr>
-            <tr>
               <td><code>focus</code></td>
               <td>
                 <p>Sets focus in the tagsinput</p>


### PR DESCRIPTION
In the examples document, removeAll was listed twice. Removed the duplicate value.
