### PR TITLE
Container and input could have possiblitty to customize classes

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -20,6 +20,8 @@
     maxChars: undefined,
     confirmKeys: [13, 44],
     delimiter: ',',
+    containerClass: '',
+    inputClass: '',
     delimiterRegex: null,
     cancelConfirmKeysOnEmpty: true,
     onTagExists: function(item, $tag) {
@@ -268,6 +270,9 @@
       makeOptionItemFunction(self.options, 'itemValue');
       makeOptionItemFunction(self.options, 'itemText');
       makeOptionFunction(self.options, 'tagClass');
+
+      self.$container.addClass(options.containerClass);
+      self.$input.addClass(options.inputClass);
 
       // Typeahead Bootstrap version 2.3.2
       if (self.options.typeahead) {

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -271,8 +271,8 @@
       makeOptionItemFunction(self.options, 'itemText');
       makeOptionFunction(self.options, 'tagClass');
 
-      self.$container.addClass(options.containerClass);
-      self.$input.addClass(options.inputClass);
+      self.$container.addClass(self.options.containerClass);
+      self.$input.addClass(self.options.inputClass);
 
       // Typeahead Bootstrap version 2.3.2
       if (self.options.typeahead) {


### PR DESCRIPTION
This pull request is to make tagsinput mark the input container and input with classes. This makes it easier to control the style of those two with CSS.
