### PR TITLE
Configurable autoResize

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -16,6 +16,7 @@
     },
     freeInput: true,
     addOnBlur: true,
+    autoResize: true,
     maxTags: undefined,
     maxChars: undefined,
     confirmKeys: [13, 44],
@@ -416,10 +417,12 @@
          }
 
         // Reset internal input's size
-        var textLength = $input.val().length,
-            wordSpace = Math.ceil(textLength / 5),
-            size = textLength + wordSpace + 1;
-        $input.attr('size', Math.max(this.inputSize, $input.val().length));
+        if (self.options.autoResize) {
+          var textLength = $input.val().length,
+              wordSpace = Math.ceil(textLength / 5),
+              size = textLength + wordSpace + 1;
+          $input.attr('size', Math.max(this.inputSize, $input.val().length));
+        }
       }, self));
 
       self.$container.on('keypress', 'input', $.proxy(function(event) {
@@ -446,10 +449,12 @@
          }
 
          // Reset internal input's size
-         var textLength = $input.val().length,
-            wordSpace = Math.ceil(textLength / 5),
-            size = textLength + wordSpace + 1;
-         $input.attr('size', Math.max(this.inputSize, $input.val().length));
+         if (self.options.autoResize) {
+           var textLength = $input.val().length,
+              wordSpace = Math.ceil(textLength / 5),
+              size = textLength + wordSpace + 1;
+           $input.attr('size', Math.max(this.inputSize, $input.val().length));
+         }
       }, self));
 
       // Remove icon clicked


### PR DESCRIPTION
Currently tagsinput creates small input and resizes it on each character added. What if one wants to have fixed size input (controlled by CSS) and doesn't want to let tagsinput to resize the input?
