### PR TITLE
Hide original input element without "display: none"

### DIFF
--- a/src/bootstrap-tagsinput.css
+++ b/src/bootstrap-tagsinput.css
@@ -53,3 +53,13 @@
 .bootstrap-tagsinput .tag [data-role="remove"]:hover:active {
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
+.bootstrap-tagsinput-hidden-accessible {
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+}

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -36,7 +36,12 @@
     this.itemsArray = [];
 
     this.$element = $(element);
-    this.$element.hide();
+
+    // Hide the original form element, but keep it accessible
+    this._tabindex = this.$element.attr('tabindex');
+    this.$element.addClass('bootstrap-tagsinput-hidden-accessible')
+        .attr('aria-hidden', 'true')
+        .attr('tabindex', '-1');
 
     this.isSelect = (element.tagName === 'SELECT');
     this.multiple = (this.isSelect && element.hasAttribute('multiple'));
@@ -484,7 +489,13 @@
 
       self.$container.remove();
       self.$element.removeData('tagsinput');
-      self.$element.show();
+      self.$element.removeClass('bootstrap-tagsinput-hidden-accessible')
+        .removeAttr('aria-hidden');
+      if (this._tabindex === undefined) {
+        self.$element.removeAttr('tabindex');
+      } else {
+        self.$element.attr('tabindex', this._tabindex);
+      }
     },
 
     /**

--- a/test/bootstrap-tagsinput/input_with_string_items.tests.js
+++ b/test/bootstrap-tagsinput/input_with_string_items.tests.js
@@ -12,7 +12,9 @@ describe("bootstrap-tagsinput", function() {
 
     testTagsInput('<input type="text" />', function() {
       it("should hide input", function() {
-        expect(this.$element.css('display')).toBe('none');
+        expect(this.$element.hasClass('bootstrap-tagsinput-hidden-accessible')).toBe(true);
+        expect(this.$element.attr('aria-hidden')).toBe('true');
+        expect(this.$element.attr('tabindex')).toBe('-1');
       });
 
       it("should add tag on when pressing ENTER", function() {


### PR DESCRIPTION
Validation frameworks such as jQuery Validation ignore hidden
inputs. Select2 uses a similar approach to hide the original input
elements.
