### PR TITLE
Add 'focus' class to the container when it gains focus

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -5,6 +5,7 @@
     tagClass: function(item) {
       return 'label label-info';
     },
+    focusClass: 'focus',
     itemValue: function(item) {
       return item ? item.toString() : item;
     },
@@ -362,6 +363,15 @@
           }, self));
         }
 
+      // Toggle the 'focus' css class on the container when it has focus
+      self.$container.on({
+        focusin: function() {
+          self.$container.addClass(self.options.focusClass);
+        },
+        focusout: function() {
+          self.$container.removeClass(self.options.focusClass);
+        },
+      });
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {
         var $input = $(event.target),

--- a/test/bootstrap-tagsinput/input_with_string_items.tests.js
+++ b/test/bootstrap-tagsinput/input_with_string_items.tests.js
@@ -111,6 +111,13 @@ describe("bootstrap-tagsinput", function() {
         this.$element.tagsinput('focus');
         expect(hasFocus(this.$tagsinput_input)).toBe(true);
       });
+
+      it("focussing input should add 'focus' class", function() {
+        this.$tagsinput_input.focus();
+        expect(this.$tagsinput.hasClass('focus')).toBe(true);
+        this.$tagsinput_input.blur();
+        expect(this.$tagsinput.hasClass('focus')).toBe(false);
+      });
     });
 
     testTagsInput('<input type="text" value="some,tags" />', function() {


### PR DESCRIPTION
Adding a focus css class allows for specific styling when the tags input field has focus. In vanilla Bootstrap for example, a focused input field has a blue hue around it. Users who wish to implement this style in their forms are left to find their own solution.