### PR TITLE
Enhancement to support Twitter typeahead.js Multiple Datasets

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -342,13 +342,15 @@
       // typeahead.js
       if (self.options.typeaheadjs) {
           var typeaheadConfig = null;
-          var typeaheadDatasets = {};
+          var typeaheadDatasets = [];
 
           // Determine if main configurations were passed or simply a dataset
           var typeaheadjs = self.options.typeaheadjs;
           if ($.isArray(typeaheadjs)) {
-            typeaheadConfig = typeaheadjs[0];
-            typeaheadDatasets = typeaheadjs[1];
+            if(typeaheadjs.length > 1){
+              typeaheadConfig = typeaheadjs[0];
+              typeaheadDatasets = typeaheadjs.slice(1);
+            }
           } else {
             typeaheadDatasets = typeaheadjs;
           }


### PR DESCRIPTION
Hi
According to [typeahead.js doc](https://github.com/twitter/typeahead.js/blob/master/doc/jquery_typeahead.md#datasets), multiple datasets are supported. However the original bootstrap-taginput implementation only accepts the first datasource.
This pull request contains new changes to get multiple datasets working, please review.
Please see http://twitter.github.io/typeahead.js/examples/#multiple-datasets for example

Thanks 
