### PR TITLE
Fix input size issue when typing text

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -450,7 +450,7 @@
         var textLength = $input.val().length,
             wordSpace = Math.ceil(textLength / 5),
             size = textLength + wordSpace + 1;
-        $input.attr('size', Math.max(this.inputSize, $input.val().length));
+        $input.attr('size', Math.max(this.inputSize, size));
       }, self));
 
       self.$container.on('keypress', 'input', $.proxy(function(event) {
@@ -480,7 +480,7 @@
          var textLength = $input.val().length,
             wordSpace = Math.ceil(textLength / 5),
             size = textLength + wordSpace + 1;
-         $input.attr('size', Math.max(this.inputSize, $input.val().length));
+         $input.attr('size', Math.max(this.inputSize, size));
       }, self));
 
       // Remove icon clicked


### PR DESCRIPTION
The text input size was slightly too small to show all the typed characters. I found out that the correct size was computed but not used. This commit fixes that.
