### PR TITLE
Fix - Take account of the delimiter into the returned value

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -274,8 +274,9 @@
           val = $.map(self.items(), function(item) {
             return self.options.itemValue(item).toString();
           });
+      var delimiter = (self.options.delimiterRegex) ? self.options.delimiterRegex : self.options.delimiter;
 
-      self.$element.val(val, true);
+      self.$element.val(val.join(delimiter), true);
 
       if (self.options.triggerChange)
         self.$element.trigger('change');


### PR DESCRIPTION
The returned value in the pushVal function wasn't taking account the delimiter option.
