### PR TITLE
Add support to typeahead custom sorter function

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -334,7 +334,7 @@
             return (text.toLowerCase().indexOf(this.query.trim().toLowerCase()) !== -1);
           },
           sorter: function (texts) {
-            return texts.sort();
+            return typeahead.sorter ? typeahead.sorter(texts) : texts.sort();
           },
           highlighter: function (text) {
             var regex = new RegExp( '(' + this.query + ')', 'gi' );


### PR DESCRIPTION
Hi, it would be really nice if we had support to custom sorter function for typeahead inside tagsinput, I did  change this locally and it worked, but I need to use tagsinput from the original source in NPM.
Also the other typeahead functions would be also nice to be customizable, but for me the custom sorter is what I need.
Thank you.
