### PR TITLE
Add grunt serve task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-zip');
   grunt.loadNpmTasks('grunt-jquerymanifest');
   grunt.loadNpmTasks('grunt-bower-task');
+	grunt.loadNpmTasks('grunt-serve');
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -72,7 +73,8 @@ module.exports = function(grunt) {
           title: '<%= pkg.title %>'
         }
       }
-    }
+    },
+    serve: {}
   });
 
   grunt.registerTask('install', ['bower']);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-jquerymanifest": "~0.1.4",
     "grunt-karma": "~0.8.3",
+    "grunt-serve": "^0.1.6",
     "grunt-zip": "~0.15.0",
     "karma": "~0.12.19",
     "karma-jasmine": "~0.1.5",


### PR DESCRIPTION
I needed to check something and just serving the example files from the file system won't work. The browser will try to request cities.json, but won't allow it because it's on the file system.
A Grunt serve task adds a small http server so requesting cities.json works now.