### PR TITLE
Clear typeahead input in timeout

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -168,7 +168,7 @@
 
       // If using typeahead, once the tag has been added, clear the typeahead value so it does not stick around in the input.
       if ($('.typeahead, .twitter-typeahead', self.$container).length) {
-        self.$input.typeahead('val', '');
+         setTimeout(function () { self.$input.val(''); }, 0);
       }
 
       if (this.isInit) {


### PR DESCRIPTION
Because typeahead will set the value of the input, sometimes after we've cleared it, which leaves the input with text we don't want.

This solution just wraps the clearing of the input in a `setTimeout` so it is performed later.