### PR TITLE
I modified the Angular directive to use the attributes `maxTags`, `maxChars`, `trimValue`, and `allowDuplicates`.

### DIFF
--- a/src/bootstrap-tagsinput-angular.js
+++ b/src/bootstrap-tagsinput-angular.js
@@ -39,6 +39,10 @@ angular.module('bootstrap-tagsinput', [])
           },
           itemValue: getItemProperty(scope, attrs.itemvalue),
           itemText : getItemProperty(scope, attrs.itemtext),
+          maxTags: !isNaN(attrs.maxTags) ? attrs.maxTags : undefined,
+          maxChars: !isNaN(attrs.maxChars) ? attrs.maxChars : undefined,
+          trimValue: attrs.trimValue === 'true' ? true : false,
+          allowDuplicates: attrs.allowDuplicates === 'true' ? true : false,
           confirmKeys : getItemProperty(scope, attrs.confirmkeys) ? JSON.parse(attrs.confirmkeys) : [13],
           tagClass : angular.isFunction(scope.$parent[attrs.tagclass]) ? scope.$parent[attrs.tagclass] : function(item) { return attrs.tagclass; }
         });


### PR DESCRIPTION
for issue 214: [maxTags is not working !! in angular version of bootstrap tags input #214](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/issues/214)

I modified the Angular directive to use the attributes `maxTags`, `maxChars`, `trimValue`, and `allowDuplicates`.