### PR TITLE
 	[bootstrap3-typeahead] add support for latest version of bootstrap3-typeahead v4.0.2 and bloodhound v0.11.1

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -329,16 +329,6 @@
           updater: function (text) {
             self.add(this.map[text]);
             return '';
-          },
-          matcher: function (text) {
-            return (text.toLowerCase().indexOf(this.query.trim().toLowerCase()) !== -1);
-          },
-          sorter: function (texts) {
-            return texts.sort();
-          },
-          highlighter: function (text) {
-            var regex = new RegExp( '(' + this.query + ')', 'gi' );
-            return text.replace( regex, "<strong>$1</strong>" );
           }
         }));
       }

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -291,7 +291,7 @@
       makeOptionItemFunction(self.options, 'itemText');
       makeOptionFunction(self.options, 'tagClass');
 
-      // Typeahead Bootstrap version 2.3.2
+      // Bootstrap-3-Typeahead (https://github.com/bassjobsen/Bootstrap-3-Typeahead)
       if (self.options.typeahead) {
         var typeahead = self.options.typeahead || {};
 
@@ -328,7 +328,7 @@
           },
           updater: function (text) {
             self.add(this.map[text]);
-            return this.map[text];
+            return '';
           },
           matcher: function (text) {
             return (text.toLowerCase().indexOf(this.query.trim().toLowerCase()) !== -1);


### PR DESCRIPTION
This will update the code to support the latest version of Bootstrap-3-Typeahead v4.0.2 (https://github.com/bassjobsen/Bootstrap-3-Typeahead) and Bloodhound v0.11.1 (https://github.com/twitter/typeahead.js/blob/master/doc/bloodhound.md)

Fixes #470 and some other issues I guess.