### PR TITLE
More tag events, insert tag at any position of the list,  freeinput number with itemValue

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -471,6 +471,14 @@
             size = textLength + wordSpace + 1;
         $input.attr('size', Math.max(this.inputSize, $input.val().length));
       }, self));
+      
+      self.$container.on('keyup', 'input', $.proxy(function(event) {
+        if(event.keyCode !== 13 && event.keyCode !== 38 && event.keyCode !== 40){
+          var $input = $(event.target);
+          var digBegin = $.Event('inputHasChanged', { val: $input.val() });
+          self.$element.trigger(digBegin);
+        }
+      }, self));
 
       self.$container.on('keypress', 'input', $.proxy(function(event) {
          var $input = $(event.target);

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -135,15 +135,17 @@
 
       // add a tag element
 
-      var $tag = $('<span id="' + htmlEncode(itemValue) + '" class="tag ' + htmlEncode(tagClass) + '">' + htmlEncode(itemText) + '<span data-role="remove"></span></span>');
+      var $tag = $('<span class="tag ' + htmlEncode(tagClass) + '">' + htmlEncode(itemText) + '<span data-role="remove"></span></span>');
       $tag.data('item', item);
       self.findInputWrapper().before($tag);
       $tag.after(' ');
+      
       //additional events
       var span = $tag[0];
       span.onclick = function(){
         self.$element.trigger($.Event('tagClicked', { item: item, span: span }));
       };
+      
       span.onmouseover = function(){
         self.$element.trigger($.Event('tagMouseOver', { item: item, span: span }));
       };

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -131,7 +131,7 @@
         return;
 
       // register item in internal array and map
-      self.itemsArray.push(item);
+      self.itemsArray.splice(self.findInputWrapper().index(), 0, item);
 
       // add a tag element
 

--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -135,16 +135,22 @@
 
       // add a tag element
 
-      var $tag = $('<span class="tag ' + htmlEncode(tagClass) + (itemTitle !== null ? ('" title="' + itemTitle) : '') + '">' + htmlEncode(itemText) + '<span data-role="remove"></span></span>');
+      var $tag = $('<span id="' + htmlEncode(itemValue) + '" class="tag ' + htmlEncode(tagClass) + '">' + htmlEncode(itemText) + '<span data-role="remove"></span></span>');
       $tag.data('item', item);
       self.findInputWrapper().before($tag);
       $tag.after(' ');
-
-      // Check to see if the tag exists in its raw or uri-encoded form
-      var optionExists = (
-        $('option[value="' + encodeURIComponent(itemValue) + '"]', self.$element).length ||
-        $('option[value="' + htmlEncode(itemValue) + '"]', self.$element).length
-      );
+      //additional events
+      var span = $tag[0];
+      span.onclick = function(){
+        self.$element.trigger($.Event('tagClicked', { item: item, span: span }));
+      };
+      span.onmouseover = function(){
+        self.$element.trigger($.Event('tagMouseOver', { item: item, span: span }));
+      };
+      
+      span.onmouseout = function(){
+        self.$element.trigger($.Event('tagMouseOut', { item: item, span: span }));
+      };
 
       // add <option /> if item represents a value not present in one of the <select />'s options
       if (self.isSelect && !optionExists) {


### PR DESCRIPTION
- Events: tagClicked, tagMouseOver, tagMouseOut, inputHasChanged;
- Available to add tag at any position of the list, not just at the end.
- When itemValue is set, freeInput can still be used (in this case if it's a number)