### PR TITLE
Initialize input with placeholder size

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -48,7 +48,7 @@
     this.inputSize = Math.max(1, this.placeholderText.length);
 
     this.$container = $('<div class="bootstrap-tagsinput"></div>');
-    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '"/>').appendTo(this.$container);
+    this.$input = $('<input type="text" placeholder="' + this.placeholderText + '" size="' + this.inputSize + '"/>').appendTo(this.$container);
 
     this.$element.before(this.$container);
 


### PR DESCRIPTION
Following the code done when reseting input size (keydown and keypress events): 
This is for an input with placeholder to not get the text cut when initialized (before any of those events to that input is triggered)

To fix this cut:
![image](https://user-images.githubusercontent.com/23286236/58557074-68760580-8215-11e9-9001-b017d1e44b79.png)
