### PR TITLE
New Line Replace By Delimeter

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -22,6 +22,7 @@
     confirmKeys: [13, 44],
     delimiter: ',',
     delimiterRegex: null,
+    pasteDelimeterForNewLine: ",",
     cancelConfirmKeysOnEmpty: false,
     onTagExists: function(item, $tag) {
       $tag.hide().fadeIn();
@@ -399,6 +400,14 @@
           self.$container.removeClass(self.options.focusClass);
         },
       });
+
+      /**
+       * Replace New Line Character with Delimeter Before further execution
+       */
+      self.$input.on("paste", $.proxy(function(event) {
+        event.preventDefault();
+        self.$input.val((event.originalEvent || event).clipboardData.getData('text/plain').replaceAll("\n", self.options.pasteDelimeterForNewLine));
+      },self));
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {
         var $input = $(event.target),


### PR DESCRIPTION
Currently, if we copy and paste multi-line text in tagsinput, it considers the new line character as space due to the `input` element.

This PR provides an option `pasteDelimeterForNewLine` which will be considered to replace the `\n` characters with the provided delimiter. The default value for this delimiter is kept as space which is the same behavior of the `input` element.

Example - 
Text copied:
test val
test 2
new test

Current Output
![image](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/assets/94886461/8c72feeb-e507-40da-8298-6fd32ad3f8df)

After Adding `pasteDelimeterForNewLine:","`
![image](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/assets/94886461/b9c97a0e-b2e2-4634-a0de-3310d94395ca)
