### PR TITLE
Fix input size when pasting

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -406,7 +406,9 @@
        */
       self.$input.on("paste", $.proxy(function(event) {
         event.preventDefault();
-        self.$input.val((event.originalEvent || event).clipboardData.getData('text/plain').replaceAll("\n", self.options.pasteDelimeterForNewLine));
+        var clipboadContent = (event.originalEvent || event).clipboardData.getData('text/plain');
+        self.$input.val(clipboadContent.replaceAll("\n", self.options.pasteDelimeterForNewLine));
+        self.$input.attr('size', clipboadContent.length);
       },self));
 
       self.$container.on('keydown', 'input', $.proxy(function(event) {


### PR DESCRIPTION
PR #25 solved the delimiter problem, but seems to have caused a bug. Currently, when we paste text into the input field, the input field will not automatically grow to the size of the pasted text. The present PR fixed this bug by adjusting the input field's size.

To illustrate, let's say we have copied this to our clipboard: *"Text that I am pasting."* And now, we want to paste it as a new tag to the input field. 

## Before this PR it looked like:
![text_that_i_am_pasting_old](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/assets/108933809/fe37685b-c239-4a23-ac56-df4f24c17e07)
**We can only see "ting.", not the entire content.**

## After this PR it correctly adjusts the size so that we can see the full pasted text:
![text_that_i_am_pasting_new](https://github.com/bootstrap-tagsinput/bootstrap-tagsinput/assets/108933809/a3eb9882-6e92-4c56-8588-377525a4131e)
**We can see the entire content "Text that I am pasting."**