### PR TITLE
Use delimiter to set val input

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -271,7 +271,7 @@
             return self.options.itemValue(item).toString();
           });
 
-      self.$element.val(val, true);
+      self.$element.val(val.join(this.delimiter), true);
 
       if (self.options.triggerChange)
         self.$element.trigger('change');


### PR DESCRIPTION
When setting option "delimiter" to say `|`. I expect my input to be saved as `item1|item2|item3`. 
